### PR TITLE
Framerate manager + pipeline abstraction improvements

### DIFF
--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamBuild.cs
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamBuild.cs
@@ -29,6 +29,8 @@ namespace Disguise.RenderStream
                 Debug.LogError("DisguiseRenderStream: RenderStream DLL not available, could not save schema");
                 return;
             }
+
+            CheckVsync();
             
             DisguiseRenderStreamSettings settings = DisguiseRenderStreamSettings.GetOrCreateSettings();
             var schema = new ManagedSchema
@@ -108,6 +110,14 @@ namespace Disguise.RenderStream
                 .SelectMany(p => p.exposedParameters()));
             
             currentScene.parameters = parameters.ToArray();
+        }
+
+        static void CheckVsync()
+        {
+            if (DisguiseFramerateManager.Enabled && DisguiseFramerateManager.VSyncIsEnabled)
+            {
+                Debug.LogWarning($"DisguiseRenderStream: {nameof(QualitySettings)}{nameof(QualitySettings.vSyncCount)} is currently enabled. For best performance disable vSync in the project settings.");
+            }
         }
     }
 }

--- a/DisguiseUnityRenderStream/Runtime/Disguise.RenderStream.asmdef
+++ b/DisguiseUnityRenderStream/Runtime/Disguise.RenderStream.asmdef
@@ -24,12 +24,12 @@
         {
             "name": "com.unity.render-pipelines.high-definition",
             "expression": "13.1.8",
-            "define": "HDRP_13_1_8_OR_NEWER"
+            "define": "HDRP"
         },
         {
             "name": "com.unity.render-pipelines.universal",
             "expression": "13.1.8",
-            "define": "URP_13_1_8_OR_NEWER"
+            "define": "URP"
         }
     ],
     "noEngineReferences": false

--- a/DisguiseUnityRenderStream/Runtime/DisguiseFramerateManager.cs
+++ b/DisguiseUnityRenderStream/Runtime/DisguiseFramerateManager.cs
@@ -5,16 +5,19 @@ namespace Disguise.RenderStream
     public static class DisguiseFramerateManager
     {
 #if ENABLE_CLUSTER_DISPLAY
-        public const bool Enabled = false;
+        public static bool Enabled => false;
 #else
-        public const bool Enabled = true;
+        public static bool Enabled => true;
 #endif
         
-        static int k_FrameRateUnlimited = -1;
+        const int k_FrameRateUnlimited = -1;
         
         public static bool FrameRateIsLimited => Application.targetFrameRate >= 0;
 
         public static bool VSyncIsEnabled => QualitySettings.vSyncCount > 0;
+
+        static bool s_WarnedVSync;
+        static bool s_WarnedFrameRate;
 
         public static void Initialize()
         {
@@ -26,14 +29,16 @@ namespace Disguise.RenderStream
         public static void Update()
         {
 #if !ENABLE_CLUSTER_DISPLAY
-            if (VSyncIsEnabled)
+            if (!s_WarnedVSync && VSyncIsEnabled)
             {
                 Debug.LogWarning($"{nameof(DisguiseFramerateManager)}: {nameof(QualitySettings)}{nameof(QualitySettings.vSyncCount)} is enabled and may affect performance.");
+                s_WarnedVSync = true;
             }
 
-            if (FrameRateIsLimited)
+            if (!s_WarnedFrameRate && FrameRateIsLimited)
             {
                 Debug.LogWarning($"{nameof(DisguiseFramerateManager)}: {nameof(Application)}{nameof(Application.targetFrameRate)} is limiting framerate and may affect performance.");
+                s_WarnedFrameRate = true;
             }
 #endif
         }

--- a/DisguiseUnityRenderStream/Runtime/DisguiseFramerateManager.cs
+++ b/DisguiseUnityRenderStream/Runtime/DisguiseFramerateManager.cs
@@ -19,6 +19,7 @@ namespace Disguise.RenderStream
         static bool s_WarnedVSync;
         static bool s_WarnedFrameRate;
 
+        [RuntimeInitializeOnLoadMethod]
         public static void Initialize()
         {
 #if !ENABLE_CLUSTER_DISPLAY

--- a/DisguiseUnityRenderStream/Runtime/DisguiseFramerateManager.cs
+++ b/DisguiseUnityRenderStream/Runtime/DisguiseFramerateManager.cs
@@ -31,13 +31,13 @@ namespace Disguise.RenderStream
 #if !ENABLE_CLUSTER_DISPLAY
             if (!s_WarnedVSync && VSyncIsEnabled)
             {
-                Debug.LogWarning($"{nameof(DisguiseFramerateManager)}: {nameof(QualitySettings)}{nameof(QualitySettings.vSyncCount)} is enabled and may affect performance.");
+                Debug.LogWarning($"{nameof(DisguiseFramerateManager)}: {nameof(QualitySettings)}.{nameof(QualitySettings.vSyncCount)} is enabled and may affect performance.");
                 s_WarnedVSync = true;
             }
 
             if (!s_WarnedFrameRate && FrameRateIsLimited)
             {
-                Debug.LogWarning($"{nameof(DisguiseFramerateManager)}: {nameof(Application)}{nameof(Application.targetFrameRate)} is limiting framerate and may affect performance.");
+                Debug.LogWarning($"{nameof(DisguiseFramerateManager)}: {nameof(Application)}.{nameof(Application.targetFrameRate)} is limiting framerate and may affect performance.");
                 s_WarnedFrameRate = true;
             }
 #endif

--- a/DisguiseUnityRenderStream/Runtime/DisguiseFramerateManager.cs
+++ b/DisguiseUnityRenderStream/Runtime/DisguiseFramerateManager.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+namespace Disguise.RenderStream
+{
+    public static class DisguiseFramerateManager
+    {
+#if ENABLE_CLUSTER_DISPLAY
+        public const bool Enabled = false;
+#else
+        public const bool Enabled = true;
+#endif
+        
+        static int k_FrameRateUnlimited = -1;
+        
+        public static bool FrameRateIsLimited => Application.targetFrameRate >= 0;
+
+        public static bool VSyncIsEnabled => QualitySettings.vSyncCount > 0;
+
+        public static void Initialize()
+        {
+#if !ENABLE_CLUSTER_DISPLAY
+            RemoveFrameLimit();
+#endif
+        }
+
+        public static void Update()
+        {
+#if !ENABLE_CLUSTER_DISPLAY
+            if (VSyncIsEnabled)
+            {
+                Debug.LogWarning($"{nameof(DisguiseFramerateManager)}: {nameof(QualitySettings)}{nameof(QualitySettings.vSyncCount)} is enabled and may affect performance.");
+            }
+
+            if (FrameRateIsLimited)
+            {
+                Debug.LogWarning($"{nameof(DisguiseFramerateManager)}: {nameof(Application)}{nameof(Application.targetFrameRate)} is limiting framerate and may affect performance.");
+            }
+#endif
+        }
+
+        static void RemoveFrameLimit()
+        {
+            Application.targetFrameRate = k_FrameRateUnlimited;
+        }
+    }
+}

--- a/DisguiseUnityRenderStream/Runtime/DisguiseRenderStream.cs
+++ b/DisguiseUnityRenderStream/Runtime/DisguiseRenderStream.cs
@@ -55,8 +55,6 @@ namespace Disguise.RenderStream
             {
                 Instance.OnSceneLoaded(scene, LoadSceneMode.Single);
             }
-
-            DisguiseFramerateManager.Initialize();
         }
 
         struct RenderStreamUpdate { }

--- a/DisguiseUnityRenderStream/Runtime/DisguiseRenderStream.cs
+++ b/DisguiseUnityRenderStream/Runtime/DisguiseRenderStream.cs
@@ -55,6 +55,8 @@ namespace Disguise.RenderStream
             {
                 Instance.OnSceneLoaded(scene, LoadSceneMode.Single);
             }
+
+            DisguiseFramerateManager.Initialize();
         }
 
         struct RenderStreamUpdate { }
@@ -440,6 +442,8 @@ namespace Disguise.RenderStream
             {
                 ProcessFrameData(LatestFrameData);
             }
+
+            DisguiseFramerateManager.Update();
         }
 
         static Camera[] getTemplateCameras()

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/CameraCapture.cs
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/CameraCapture.cs
@@ -191,6 +191,10 @@ namespace Disguise.RenderStream
 
         void OnEnable()
         {
+#if (!HDRP) && (!URP)
+            Debug.LogError($"No supported render pipeline was found for {nameof(CameraCapture)}.");
+#endif
+            
             RenderPipelineManager.endCameraRendering += OnEndCameraRendering;
 
             if (m_depthCopy == null)
@@ -228,7 +232,7 @@ namespace Disguise.RenderStream
             
             if (!desc.IsValid)
             {
-                Debug.LogWarning("CameraCapture has invalid description, will be disabled.");
+                Debug.LogWarning($"{nameof(CameraCapture)} has invalid description, will be disabled.");
                 return;
             }
 
@@ -244,9 +248,9 @@ namespace Disguise.RenderStream
             }
             
 #if DEBUG
-            m_cameraTexture.name = $"CameraCapture Camera Texture Initial {m_cameraTexture.width}x{m_cameraTexture.height}";
+            m_cameraTexture.name = $"{nameof(CameraCapture)} Camera Texture Initial {m_cameraTexture.width}x{m_cameraTexture.height}";
             if (m_depthTexture != null)
-                m_depthTexture.name = $"CameraCapture Depth Copy Texture Initial {m_depthTexture.width}x{m_depthTexture.height}";
+                m_depthTexture.name = $"{nameof(CameraCapture)} Depth Copy Texture Initial {m_depthTexture.width}x{m_depthTexture.height}";
             m_HasSetSecondNames = false;
 #endif
         }
@@ -277,9 +281,9 @@ namespace Disguise.RenderStream
             // This second naming step will name the resolved textures which Unity creates in a deferred manner.
             if (!m_HasSetSecondNames)
             {
-                m_cameraTexture.name = $"CameraCapture Camera Texture {m_cameraTexture.width}x{m_cameraTexture.height}";
+                m_cameraTexture.name = $"{nameof(CameraCapture)} Camera Texture {m_cameraTexture.width}x{m_cameraTexture.height}";
                 if (m_depthTexture != null)
-                    m_depthTexture.name = $"CameraCapture Depth Copy Texture {m_depthTexture.width}x{m_depthTexture.height}";
+                    m_depthTexture.name = $"{nameof(CameraCapture)} Depth Copy Texture {m_depthTexture.width}x{m_depthTexture.height}";
                 m_HasSetSecondNames = true;
             }
 #endif

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/DepthCopy.cs
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/DepthCopy.cs
@@ -10,10 +10,12 @@ namespace Disguise.RenderStream
     /// </summary>
     class DepthCopy
     {
-#if HDRP_13_1_8_OR_NEWER
+#if HDRP
         const string k_ShaderName = "Hidden/Disguise/RenderStream/DepthCopyHDRP";
-#elif URP_13_1_8_OR_NEWER
+#elif URP
         const string k_ShaderName = "Hidden/Disguise/RenderStream/DepthCopyURP";
+#else
+        const string k_ShaderName = null;
 #endif
         
         /// <summary>
@@ -118,8 +120,12 @@ namespace Disguise.RenderStream
         
         static DepthCopy()
         {
+#if (!HDRP) && !(SRP)
+            Debug.LogError($"No supported render pipeline was found for {nameof(DepthCopy)}.");
+#endif
+            
             s_shaderVariantResources.Create(k_ShaderName, k_ShaderPass);
-            Assert.IsTrue(s_shaderVariantResources.IsLoaded, "Couldn't load the shader resources for DepthCopy");
+            Assert.IsTrue(s_shaderVariantResources.IsLoaded, $"Couldn't load the shader resources for {nameof(DepthCopy)}");
         }
 
         public DepthCopy()
@@ -156,7 +162,7 @@ namespace Disguise.RenderStream
         {
             // HDRP cameras always have a depth texture
             
-#if URP_13_1_8_OR_NEWER
+#if URP
             var pipeline = GraphicsSettings.currentRenderPipeline as UnityEngine.Rendering.Universal.UniversalRenderPipelineAsset;
             Assert.IsNotNull(pipeline);
             if (!pipeline.supportsCameraDepthTexture)

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/DepthCopy.cs
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/DepthCopy.cs
@@ -120,7 +120,7 @@ namespace Disguise.RenderStream
         
         static DepthCopy()
         {
-#if (!HDRP) && !(SRP)
+#if (!HDRP) && !(URP)
             Debug.LogError($"No supported render pipeline was found for {nameof(DepthCopy)}.");
 #endif
             

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/Presenter.cs
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/Presenter.cs
@@ -18,9 +18,9 @@ namespace Disguise.RenderStream
         {
             /// <summary>
             /// Stretches the source to have the same size as the destination.
-            /// The aspect ratio is lost.
+            /// The aspect ratio may be lost.
             /// </summary>
-            Fill,
+            Stretch,
             
             /// <summary>
             /// The source isn't scaled at all but it's centered within the destination.
@@ -47,7 +47,7 @@ namespace Disguise.RenderStream
             /// The source is scaled while conserving the aspect ratio to fill the destination.
             /// It can overflow but won't leave black bars on the sides.
             /// </summary>
-            FillAspectRatio
+            Fill
         }
 
         /// <summary>
@@ -58,8 +58,8 @@ namespace Disguise.RenderStream
         {
             switch (strategy)
             {
-                case Strategy.Fill:
-                    return Fill(srcSize, dstSize);
+                case Strategy.Stretch:
+                    return Stretch(srcSize, dstSize);
                 case Strategy.NoResize:
                     return NoResize(srcSize, dstSize);
                 case Strategy.FitWidth:
@@ -68,14 +68,14 @@ namespace Disguise.RenderStream
                     return FitHeight(srcSize, dstSize);
                 case Strategy.Letterbox:
                     return Letterbox(srcSize, dstSize);
-                case Strategy.FillAspectRatio:
-                    return FillAspectRatio(srcSize, dstSize);
+                case Strategy.Fill:
+                    return Fill(srcSize, dstSize);
                 default:
                     throw new NotImplementedException();
             }
         }
         
-        static Vector4 Fill(Vector2 srcSize, Vector2 dstSize)
+        static Vector4 Stretch(Vector2 srcSize, Vector2 dstSize)
         {
             return new Vector4(1f, 1f, 0f, 0f);
         }
@@ -115,7 +115,7 @@ namespace Disguise.RenderStream
                 return FitHeight(srcSize, dstSize);
         }
         
-        static Vector4 FillAspectRatio(Vector2 srcSize, Vector2 dstSize)
+        static Vector4 Fill(Vector2 srcSize, Vector2 dstSize)
         {
             var scrAspect = AspectRatio(srcSize);
             var dstAspect = AspectRatio(dstSize);
@@ -170,7 +170,7 @@ namespace Disguise.RenderStream
         RenderTexture m_source;
         
         [SerializeField]
-        PresenterStrategy.Strategy m_strategy = PresenterStrategy.Strategy.FillAspectRatio;
+        PresenterStrategy.Strategy m_strategy = PresenterStrategy.Strategy.Fill;
 
         [SerializeField]
         bool m_clearScreen;


### PR DESCRIPTION
Framerate manager:
* The goal is to let Disguise exclusively drive the framerate and to only block while waiting for the next Disguise frame data. [vSyncCount](https://docs.unity3d.com/ScriptReference/QualitySettings-vSyncCount.html) and [targetFrameRate](https://docs.unity3d.com/ScriptReference/Application-targetFrameRate.html) are the contributing factors.
* Warns when vsync is enabled at build-time. Frame limiting doesn't have a project setting to check at build-time.
* Warns when vsync or frame limiting are enabled at runtime. They could be enabled anytime by code outside this package. Checking every frame is the safest option.
* Disables frame limiting on initialization (there's no project setting for it).
* No strong opinions on the code/structure as long as it achieves the same goals.
* No-op when the ClusterDisplay package is used because it handles both settings

Cleanup:
* Removed redundant versions in HDRP/URP define names
* Direct feedback when neither HDRP/URP dependencies are fulfilled
* Renamed presenter strategies: Fill to Stretch and FillAspectRatio to Fill
* nameof() in string literals more robust