### PR TITLE
Input textures DX12 support

### DIFF
--- a/DisguiseUnityRenderStream/Runtime/DisguiseRenderStream.cs
+++ b/DisguiseUnityRenderStream/Runtime/DisguiseRenderStream.cs
@@ -440,7 +440,7 @@ namespace Disguise.RenderStream
                     {
                         Width = (int)imageData[i].width,
                         Height = (int)imageData[i].height,
-                        Format = PluginEntry.ToTextureFormat(imageData[i].format),
+                        Format = imageData[i].format,
                         Linear = true
                     });
 

--- a/DisguiseUnityRenderStream/Runtime/DisguiseTextures.cs
+++ b/DisguiseUnityRenderStream/Runtime/DisguiseTextures.cs
@@ -21,14 +21,14 @@ namespace Disguise.RenderStream
             }
         }
         
-        public static Texture2D CreateTexture(int width, int height, RSPixelFormat format, string name)
+        public static Texture2D CreateTexture(int width, int height, RSPixelFormat format, bool linear, string name)
         {
             Texture2D texture = null;
             
             switch (PluginEntry.instance.GraphicsDeviceType)
             {
                 case GraphicsDeviceType.Direct3D11:
-                    texture = new Texture2D(width, height, PluginEntry.ToTextureFormat(format), false, false);
+                    texture = new Texture2D(width, height, PluginEntry.ToTextureFormat(format), false, linear);
                     break;
                 
                 case GraphicsDeviceType.Direct3D12:
@@ -39,12 +39,12 @@ namespace Disguise.RenderStream
                     if (heapFlag == UseDX12SharedHeapFlag.RS_DX12_USE_SHARED_HEAP_FLAG)
                     {
                         var nativeTex = NativeRenderingPlugin.CreateNativeTexture(name, width, height, ToNativeRenderingPluginFormat(format));
-                        texture = Texture2D.CreateExternalTexture(width, height, PluginEntry.ToTextureFormat(format), false, false, nativeTex);
+                        texture = Texture2D.CreateExternalTexture(width, height, PluginEntry.ToTextureFormat(format), false, linear, nativeTex);
                         break;
                     }
                     else
                     {
-                        texture = new Texture2D(width, height, PluginEntry.ToTextureFormat(format), false, false);
+                        texture = new Texture2D(width, height, PluginEntry.ToTextureFormat(format), false, linear);
                         break;
                     }
             }

--- a/DisguiseUnityRenderStream/Runtime/FrameSender.cs
+++ b/DisguiseUnityRenderStream/Runtime/FrameSender.cs
@@ -42,7 +42,7 @@ namespace Disguise.RenderStream
 
             m_frameRegion = new Rect(stream.clipping.left, stream.clipping.top, stream.clipping.right - stream.clipping.left, stream.clipping.bottom - stream.clipping.top);
 
-            m_convertedTex = DisguiseTextures.CreateTexture(m_description.m_width, m_description.m_height, m_pixelFormat, stream.name + " Converted Texture");
+            m_convertedTex = DisguiseTextures.CreateTexture(m_description.m_width, m_description.m_height, m_pixelFormat, false, stream.name + " Converted Texture");
             if (m_convertedTex == null)
             {
                 Debug.LogError("Failed to create texture for Disguise");

--- a/DisguiseUnityRenderStream/Runtime/TemporaryTexture2DManager.cs
+++ b/DisguiseUnityRenderStream/Runtime/TemporaryTexture2DManager.cs
@@ -182,7 +182,7 @@ namespace Disguise.RenderStream
         {
             DebugLog(DebugTrace, $"Created texture: {descriptor}");
             
-            return DisguiseTextures.CreateTexture(descriptor.Width, descriptor.Height, descriptor.Format, true, null);
+            return DisguiseTextures.CreateTexture(descriptor.Width, descriptor.Height, descriptor.Format, descriptor.Linear, null);
         }
 
         void DestroyTexture(Texture2D texture)

--- a/DisguiseUnityRenderStream/Runtime/TemporaryTexture2DManager.cs
+++ b/DisguiseUnityRenderStream/Runtime/TemporaryTexture2DManager.cs
@@ -11,7 +11,7 @@ namespace Disguise.RenderStream
     {
         public int Width;
         public int Height;
-        public TextureFormat Format;
+        public RSPixelFormat Format;
         public bool Linear;
 
         /// <summary>
@@ -182,12 +182,7 @@ namespace Disguise.RenderStream
         {
             DebugLog(DebugTrace, $"Created texture: {descriptor}");
             
-            return new Texture2D(
-                descriptor.Width,
-                descriptor.Height,
-                descriptor.Format, 
-                false,
-                descriptor.Linear);
+            return DisguiseTextures.CreateTexture(descriptor.Width, descriptor.Height, descriptor.Format, true, null);
         }
 
         void DestroyTexture(Texture2D texture)


### PR DESCRIPTION
The input textures had to go through the same `DisguiseTextures` textures codepath that the output textures use.

It ensures that the required `D3D12_HEAP_FLAG_SHARED` flag is set in `NativeRenderingPlugin::CreateTexture` (`DX12Texture.h`).