### PR TITLE
Fixed compiler warnings in 2023.1 or newer

### DIFF
--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamBuild.cs
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamBuild.cs
@@ -106,7 +106,7 @@ namespace Disguise.RenderStream
             var currentScene = schema.scenes[sceneIndex];
 
             var parameters = currentScene.parameters
-                .Concat(Object.FindObjectsOfType<DisguiseRemoteParameters>()
+                .Concat(Object.FindObjectsByType<DisguiseRemoteParameters>(FindObjectsSortMode.InstanceID)
                 .SelectMany(p => p.exposedParameters()));
             
             currentScene.parameters = parameters.ToArray();

--- a/DisguiseUnityRenderStream/Editor/RenderingPipelineDefines.cs
+++ b/DisguiseUnityRenderStream/Editor/RenderingPipelineDefines.cs
@@ -80,9 +80,15 @@ public class RenderingPipelineDefines
     {
         var target = EditorUserBuildSettings.activeBuildTarget;
         var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(target);
-        var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
         
+#if UNITY_2023_1_OR_NEWER
+        var namedBuildTarget = UnityEditor.Build.NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup);
+        PlayerSettings.GetScriptingDefineSymbols(namedBuildTarget, out var defines);
+        return defines.ToList();
+#else
+        var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
         return defines.Split(';').ToList();
+#endif
     }
 
     public static void SetDefines(List<string> definesList)
@@ -91,6 +97,11 @@ public class RenderingPipelineDefines
         var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(target);
         var defines = string.Join(";", definesList.ToArray());
 
+#if UNITY_2023_1_OR_NEWER
+        var namedBuildTarget = UnityEditor.Build.NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup);
+        PlayerSettings.SetScriptingDefineSymbols(namedBuildTarget, defines);
+#else
         PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defines);
+#endif
     }
 }

--- a/DisguiseUnityRenderStream/Runtime/Disguise.RenderStream.asmdef
+++ b/DisguiseUnityRenderStream/Runtime/Disguise.RenderStream.asmdef
@@ -24,12 +24,12 @@
         {
             "name": "com.unity.render-pipelines.high-definition",
             "expression": "13.1.8",
-            "define": "HDRP"
+            "define": "HDRP_VERSION_SUPPORTED"
         },
         {
             "name": "com.unity.render-pipelines.universal",
             "expression": "13.1.8",
-            "define": "URP"
+            "define": "URP_VERSION_SUPPORTED"
         }
     ],
     "noEngineReferences": false

--- a/DisguiseUnityRenderStream/Runtime/DisguiseRenderStream.cs
+++ b/DisguiseUnityRenderStream/Runtime/DisguiseRenderStream.cs
@@ -96,7 +96,7 @@ namespace Disguise.RenderStream
                     sceneIndex = loadedScene.buildIndex;
                     break;
             }
-            DisguiseRemoteParameters[] remoteParameters = UnityEngine.Object.FindObjectsOfType(typeof(DisguiseRemoteParameters)) as DisguiseRemoteParameters[];
+            DisguiseRemoteParameters[] remoteParameters = UnityEngine.Object.FindObjectsByType(typeof(DisguiseRemoteParameters), FindObjectsSortMode.None) as DisguiseRemoteParameters[];
             ManagedRemoteParameters scene = m_Schema.scenes[sceneIndex];
             m_SceneFields[sceneIndex] = new SceneFields{ numerical = new List<ObjectField>(), images = new List<ObjectField>(), texts = new List<ObjectField>() };
             SceneFields fields = m_SceneFields[sceneIndex];

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/CameraCapture.cs
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/CameraCapture.cs
@@ -191,7 +191,7 @@ namespace Disguise.RenderStream
 
         void OnEnable()
         {
-#if (!HDRP) && (!URP)
+#if !(UNITY_PIPELINE_HDRP && HDRP) && !(UNITY_PIPELINE_URP && URP)
             Debug.LogError($"No supported render pipeline was found for {nameof(CameraCapture)}.");
 #endif
             

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/CameraCapture.cs
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/CameraCapture.cs
@@ -191,7 +191,7 @@ namespace Disguise.RenderStream
 
         void OnEnable()
         {
-#if !(UNITY_PIPELINE_HDRP && HDRP) && !(UNITY_PIPELINE_URP && URP)
+#if !(UNITY_PIPELINE_HDRP && HDRP_VERSION_SUPPORTED) && !(UNITY_PIPELINE_URP && URP_VERSION_SUPPORTED)
             Debug.LogError($"No supported render pipeline was found for {nameof(CameraCapture)}.");
 #endif
             

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/DepthCopy.cs
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/DepthCopy.cs
@@ -10,9 +10,9 @@ namespace Disguise.RenderStream
     /// </summary>
     class DepthCopy
     {
-#if HDRP
+#if UNITY_PIPELINE_HDRP && HDRP
         const string k_ShaderName = "Hidden/Disguise/RenderStream/DepthCopyHDRP";
-#elif URP
+#elif UNITY_PIPELINE_URP && URP
         const string k_ShaderName = "Hidden/Disguise/RenderStream/DepthCopyURP";
 #else
         const string k_ShaderName = null;
@@ -121,7 +121,7 @@ namespace Disguise.RenderStream
         static DepthCopy()
         {
 #if DISGUISE_CAPTURE_DEPTH
-#if (!HDRP) && !(URP)
+#if !(UNITY_PIPELINE_HDRP && HDRP) && !(UNITY_PIPELINE_URP && URP)
             Debug.LogError($"No supported render pipeline was found for {nameof(DepthCopy)}.");
 #endif
             
@@ -168,7 +168,7 @@ namespace Disguise.RenderStream
         {
             // HDRP cameras always have a depth texture
             
-#if URP
+#if UNITY_PIPELINE_URP && URP
             var pipeline = GraphicsSettings.currentRenderPipeline as UnityEngine.Rendering.Universal.UniversalRenderPipelineAsset;
             Assert.IsNotNull(pipeline);
             if (!pipeline.supportsCameraDepthTexture)

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/DepthCopy.cs
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/DepthCopy.cs
@@ -10,9 +10,9 @@ namespace Disguise.RenderStream
     /// </summary>
     class DepthCopy
     {
-#if UNITY_PIPELINE_HDRP && HDRP
+#if UNITY_PIPELINE_HDRP && HDRP_VERSION_SUPPORTED
         const string k_ShaderName = "Hidden/Disguise/RenderStream/DepthCopyHDRP";
-#elif UNITY_PIPELINE_URP && URP
+#elif UNITY_PIPELINE_URP && URP_VERSION_SUPPORTED
         const string k_ShaderName = "Hidden/Disguise/RenderStream/DepthCopyURP";
 #else
         const string k_ShaderName = null;
@@ -121,7 +121,7 @@ namespace Disguise.RenderStream
         static DepthCopy()
         {
 #if DISGUISE_CAPTURE_DEPTH
-#if !(UNITY_PIPELINE_HDRP && HDRP) && !(UNITY_PIPELINE_URP && URP)
+#if !(UNITY_PIPELINE_HDRP && HDRP_VERSION_SUPPORTED) && !(UNITY_PIPELINE_URP && URP_VERSION_SUPPORTED)
             Debug.LogError($"No supported render pipeline was found for {nameof(DepthCopy)}.");
 #endif
             
@@ -168,7 +168,7 @@ namespace Disguise.RenderStream
         {
             // HDRP cameras always have a depth texture
             
-#if UNITY_PIPELINE_URP && URP
+#if UNITY_PIPELINE_URP && URP_VERSION_SUPPORTED
             var pipeline = GraphicsSettings.currentRenderPipeline as UnityEngine.Rendering.Universal.UniversalRenderPipelineAsset;
             Assert.IsNotNull(pipeline);
             if (!pipeline.supportsCameraDepthTexture)

--- a/DisguiseUnityRenderStream/Runtime/PluginEntry.cs
+++ b/DisguiseUnityRenderStream/Runtime/PluginEntry.cs
@@ -780,6 +780,7 @@ namespace Disguise.RenderStream
                 Debug.LogError(string.Format("Failed to initialise: {0}", error));
             else
             {
+#if !UNITY_EDITOR
                 switch (GraphicsDeviceType)
                 {
                     case GraphicsDeviceType.Direct3D11:
@@ -809,6 +810,7 @@ namespace Disguise.RenderStream
                         
                         break;
                 }
+#endif
             }
 
             Debug.Log("Loaded RenderStream");

--- a/DisguiseUnityRenderStream/Runtime/PluginEntry.cs
+++ b/DisguiseUnityRenderStream/Runtime/PluginEntry.cs
@@ -780,7 +780,6 @@ namespace Disguise.RenderStream
                 Debug.LogError(string.Format("Failed to initialise: {0}", error));
             else
             {
-#if !UNITY_EDITOR
                 switch (GraphicsDeviceType)
                 {
                     case GraphicsDeviceType.Direct3D11:
@@ -810,7 +809,6 @@ namespace Disguise.RenderStream
                         
                         break;
                 }
-#endif
             }
 
             Debug.Log("Loaded RenderStream");


### PR DESCRIPTION
Also improved render pipeline selection by using the existing `RenderPipelineDefines.cs`.

A project can theoretically use both HDRP & URP so packages should rely on the graphics settings to detect the active pipeline. Combined with the assembly version define to ensure minimum version.