### PR TITLE
Removed scripting API limitations

### DIFF
--- a/DisguiseUnityRenderStream/Runtime/Util/RegistryWrapper.cs
+++ b/DisguiseUnityRenderStream/Runtime/Util/RegistryWrapper.cs
@@ -4,7 +4,11 @@ using System.Text;
 
 namespace Disguise.RenderStream.Utils
 {
-    // https://www.pinvoke.net/default.aspx/advapi32/regopenkeyex.html
+    /// <summary>
+    /// This is a P/Invoke alternative to the Microsoft.Win32.Registry API which isn't supported across all of our .NET standards.
+    /// 
+    /// https://www.pinvoke.net/default.aspx/advapi32/regopenkeyex.html was used as reference.
+    /// </summary>
     static class RegistryWrapper
     {
         public static UIntPtr HKEY_LOCAL_MACHINE = new UIntPtr(0x80000002u);

--- a/DisguiseUnityRenderStream/Runtime/Util/RegistryWrapper.cs
+++ b/DisguiseUnityRenderStream/Runtime/Util/RegistryWrapper.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Disguise.RenderStream.Utils
+{
+    // https://www.pinvoke.net/default.aspx/advapi32/regopenkeyex.html
+    static class RegistryWrapper
+    {
+        public static UIntPtr HKEY_LOCAL_MACHINE = new UIntPtr(0x80000002u);
+        public static UIntPtr HKEY_CURRENT_USER  = new UIntPtr(0x80000001u);
+
+        public enum ReadRegKeyResult
+        {
+            Success,
+            OpenFailed,
+            QueryValueFailed,
+            TypeNotSupported
+        }
+
+        // Only supports REG_SZ registry value type
+        public static ReadRegKeyResult ReadRegKey(UIntPtr rootKey, string keyPath, string valueName, out string value)
+        {
+            value = null;
+            
+            if (Native.RegOpenKeyEx(rootKey, keyPath, 0, Native.KEY_READ, out var hKey) == 0)
+            {
+                uint size = 1024;
+                StringBuilder keyBuffer = new StringBuilder((int)size);
+
+                if (Native.RegQueryValueEx(hKey, valueName, IntPtr.Zero, out var type, keyBuffer, ref size) == 0)
+                {
+                    Native.RegCloseKey(hKey);
+
+                    if (type == Native.REG_SZ)
+                    {
+                        value = keyBuffer.ToString();
+                        return ReadRegKeyResult.Success;
+                    }
+
+                    return ReadRegKeyResult.TypeNotSupported;
+                }
+                
+                Native.RegCloseKey(hKey);
+                return ReadRegKeyResult.QueryValueFailed;
+            }
+
+            return ReadRegKeyResult.OpenFailed;
+        }
+        
+        static class Native
+        {
+            const string advapidll = "advapi32.dll";
+            
+            public const int KEY_READ = 0x20019;
+
+            public const uint REG_NONE = 0x00000000;
+            public const uint REG_SZ = 0x00000001;
+            
+            [DllImport(advapidll, CharSet = CharSet.Auto, SetLastError = true)]
+            public static extern int RegOpenKeyEx(
+                UIntPtr hKey,
+                string subKey,
+                int ulOptions,
+                int samDesired,
+                out UIntPtr hkResult);
+            
+            [DllImport(advapidll, CharSet = CharSet.Auto, SetLastError = true)]
+            public static extern uint RegQueryValueEx(
+                UIntPtr hKey,
+                string lpValueName,
+                IntPtr lpReserved,
+                out uint lpType,
+                StringBuilder lpData,
+                ref uint lpcbData);
+            
+            [DllImport(advapidll, SetLastError = true)]
+            public static extern int RegCloseKey(UIntPtr hKey);
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -9,10 +9,7 @@ A **Demo Unity Project** can be found on the [disguise Resources page](https://d
 ## Importing the RenderStream Unity Plugin
 
 *  Copy/Import the top-level **DisguiseUnityRenderStream** folder to your Unity Project's **Assets** folder.
-*  If you get an error RegistryKey/Registry is not part of namespace Microsoft.Win32 go to File > Build Settings > Player Settings... > Other Settings:
-    *  If available **change Api Compatibility level to .NET 4.x.**
-    *  Else, change Scripting runtime version to .NET 3.5 equivalent.
-    *  If there is an error about unsafe code tick allow 'unsafe' code, this is project wide and should not be done unless unity ignores the asmdef for this plugin.
+*  If there is an error about unsafe code tick allow 'unsafe' code, this is project wide and should not be done unless unity ignores the asmdef for this plugin.
  
 ## Using the RenderStream Unity Plugin
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,9 @@ A **Demo Unity Project** can be found on the [disguise Resources page](https://d
 ## Importing the RenderStream Unity Plugin
 
 *  Copy/Import the top-level **DisguiseUnityRenderStream** folder to your Unity Project's **Assets** folder.
-*  If there is an error about unsafe code tick allow 'unsafe' code, this is project wide and should not be done unless unity ignores the asmdef for this plugin.
+*  If there is an error about unsafe code:
+    *  Go to File > Build Settings > Player Settings... > Other Settings
+    *  Tick allow 'unsafe' code, this is project wide and should not be done unless Unity ignores the asmdef for this plugin.
  
 ## Using the RenderStream Unity Plugin
 


### PR DESCRIPTION
Simplifies user setup.

It should work for Mono/IL2CPP and all .Net versions but I haven't tested with IL2CPP yet.

Edit: IL2CPP is not supported in dev branch, WIP: https://github.com/wenzhang-unity/RenderStream-Unity/pull/18

Possible improvements:
* Support other registry value types besides REG_SZ
* Retrieve specific Windows error codes (GetLastError)
* Format the Windows error codes to be human-readable (FormatMessage)