### PR TITLE
Project settings UI

### DIFF
--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.cs
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.cs
@@ -1,0 +1,35 @@
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Disguise.RenderStream
+{
+    [CustomEditor(typeof(DisguiseRenderStreamSettings))]
+    class DisguiseRenderStreamSettingsEditor : Editor
+    {
+        public static class Style
+        {
+            public const string DisguiseSettingsContainer = "disguise-settings-container";
+            public const string DisguiseSettingsTitle = "disguise-settings-title";
+        }
+        
+        [SerializeField]
+        VisualTreeAsset m_Layout;
+        
+        [SerializeField]
+        StyleSheet m_Style;
+        
+        public override VisualElement CreateInspectorGUI()
+        {
+            var root = new VisualElement();
+            
+            m_Layout.CloneTree(root);
+            root.styleSheets.Add(m_Style);
+            
+            root.Bind(serializedObject);
+
+            return root;
+        }
+    }
+}

--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.cs.meta
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: d85289020b1f03e4981e88ece03dbacf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - m_Layout: {fileID: 9197481963319205126, guid: 507d9ffa39ec44b419ba9ab3bbcd1cab, type: 3}
+  - m_Style: {fileID: 7433441132597879392, guid: fa44cd66f158c0447a66c89089cc0e82, type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.uss
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.uss
@@ -1,0 +1,12 @@
+.disguise-settings-container
+{
+    margin-left: 9px;
+    margin-top: 1px;
+}
+
+.disguise-settings-title
+{
+    font-size: 19px;
+    -unity-font-style: bold;
+    margin-bottom: 12px;
+}

--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.uss.meta
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa44cd66f158c0447a66c89089cc0e82
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.uxml
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.uxml
@@ -1,0 +1,4 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
+    <uie:PropertyField label="Scene Control" binding-path="sceneControl" />
+    <uie:PropertyField label="Unity Debug Window Presenter" binding-path="enableUnityDebugWindowPresenter" />
+</ui:UXML>

--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.uxml.meta
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsEditor.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 507d9ffa39ec44b419ba9ab3bbcd1cab
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsProvider.cs
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsProvider.cs
@@ -1,0 +1,39 @@
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace Disguise.RenderStream
+{
+    static class DisguiseRenderStreamSettingsProvider
+    {
+        static readonly string k_SettingsPath = "Project/DisguiseRenderStream";
+        const string k_StyleSheetCommon = "Packages/com.unity.cluster-display/Editor/UI/SettingsWindowCommon.uss";
+
+        class Contents
+        {
+            public const string SettingsName = "Disguise RenderStream";
+        }
+
+        [SettingsProvider]
+        static SettingsProvider CreateSettingsProvider() =>
+            new (k_SettingsPath, SettingsScope.Project)
+            {
+                label = Contents.SettingsName,
+                activateHandler = (searchContext, parentElement) =>
+                {
+                    var settings = DisguiseRenderStreamSettings.GetOrCreateSettings();
+                    var editor = Editor.CreateEditor(settings);
+
+                    var gui = editor.CreateInspectorGUI();
+                    gui.AddToClassList(DisguiseRenderStreamSettingsEditor.Style.DisguiseSettingsContainer);
+                    
+                    var title = new Label { text = Contents.SettingsName };
+                    title.AddToClassList(DisguiseRenderStreamSettingsEditor.Style.DisguiseSettingsTitle);
+                    gui.Insert(0, title);
+                    
+                    parentElement.Add(gui);
+                },
+                keywords = SettingsProvider.GetSearchKeywordsFromSerializedObject(new SerializedObject(DisguiseRenderStreamSettings.GetOrCreateSettings()))
+            };
+    }
+}

--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsProvider.cs
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsProvider.cs
@@ -1,5 +1,4 @@
 using UnityEditor;
-using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 
 namespace Disguise.RenderStream
@@ -7,7 +6,6 @@ namespace Disguise.RenderStream
     static class DisguiseRenderStreamSettingsProvider
     {
         static readonly string k_SettingsPath = "Project/DisguiseRenderStream";
-        const string k_StyleSheetCommon = "Packages/com.unity.cluster-display/Editor/UI/SettingsWindowCommon.uss";
 
         class Contents
         {

--- a/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsProvider.cs.meta
+++ b/DisguiseUnityRenderStream/Editor/DisguiseRenderStreamSettingsProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 283858074c5af2045926847f746495ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/AssemblyInfo.cs.meta
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a526d157660a6d34db40073d2c776562
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/Disguise.RenderStream.PipelineAbstraction.asmdef.meta
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/Disguise.RenderStream.PipelineAbstraction.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 690973e5dff7e66418d830800339e71f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DisguiseUnityRenderStream/Runtime/Util/AutoDisposable.cs.meta
+++ b/DisguiseUnityRenderStream/Runtime/Util/AutoDisposable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4209034702abda0428aa6f6428d6927c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/84032434/229603388-d1eb6e0b-8b09-4206-84c8-bf0dca22e965.png)

`DisguiseRenderStreamSettingsEditor.cs` is shared for both the the Inspector and Project Settings windows. The uxml and uss files are assigned as default references in `DisguiseRenderStreamSettingsEditor.cs.meta`.

The `DisguiseRenderStreamSettingsProvider.cs` code is copied from Cluster Display with minor changes.

Also added a few missing .meta files from the last 2 PRs.