### PR TITLE
Graphics callbacks simplification

### DIFF
--- a/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/CameraCapturePresenter.cs
+++ b/DisguiseUnityRenderStream/Runtime/PipelineAbstraction/CameraCapturePresenter.cs
@@ -59,9 +59,11 @@ namespace Disguise.RenderStream
                 m_cameraCapture = GetComponent<CameraCapture>();
         }
         
-        void Update()
+        protected override void Update()
         {
             Assign(m_cameraCapture);
+            
+            base.Update();
         }
 
         void Assign(CameraCapture capture)


### PR DESCRIPTION
Scott suggested a better way to run graphics tasks at the start or end of the frame.

Outside SRPs, we can use `Graphics.ExecuteCommandBuffer` (unlike the other `Graphics.*` methods, it doesn't stall the main thread and only enqueues the commands for the render thread) instead of `ScriptableRenderContext.ExecuteCommandBuffer`.