### PR TITLE
Fix texture format for uncompressed RenderStream formats

### DIFF
--- a/Runtime/DisguiseTextures.cs
+++ b/Runtime/DisguiseTextures.cs
@@ -25,7 +25,9 @@ namespace Disguise.RenderStream
                     if (heapFlag == UseDX12SharedHeapFlag.RS_DX12_USE_SHARED_HEAP_FLAG)
                     {
                         var nativeTex = NativeRenderingPlugin.CreateNativeTexture(name, width, height, format, sRGB);
-                        texture = Texture2D.CreateExternalTexture(width, height, PluginEntry.ToTextureFormat(format), false, !sRGB, nativeTex);
+                        var graphicsFormat = PluginEntry.ToGraphicsFormat(format, sRGB);
+                        var textureFormat = GraphicsFormatUtility.GetTextureFormat(graphicsFormat);
+                        texture = Texture2D.CreateExternalTexture(width, height, textureFormat, false, !sRGB, nativeTex);
                         
                         break;
                     }

--- a/Runtime/PluginEntry.cs
+++ b/Runtime/PluginEntry.cs
@@ -55,24 +55,6 @@ namespace Disguise.RenderStream
                 _ => throw new ArgumentOutOfRangeException()
             };
         }
-        
-        /// <summary>
-        /// Returns the <see cref="TextureFormat"/> that matches a RenderStream <see cref="RSPixelFormat"/>.
-        /// This should really only be used for <see cref="Texture2D.CreateExternalTexture"/>,
-        /// and not for actually creating textures because it doesn't carry any color space information.
-        /// </summary>
-        /// <remarks>Should match NativeRenderingPlugin::ToDXFormat in the native plugin's DX12Texture.h.</remarks>
-        public static TextureFormat ToTextureFormat(RSPixelFormat fmt)
-        {
-            return fmt switch
-            {
-                RSPixelFormat.RS_FMT_BGRA8 or RSPixelFormat.RS_FMT_BGRX8 => TextureFormat.BGRA32,
-                RSPixelFormat.RS_FMT_RGBA32F => TextureFormat.RGBAFloat,
-                RSPixelFormat.RS_FMT_RGBA16 => TextureFormat.RGBA64,
-                RSPixelFormat.RS_FMT_RGBA8 or RSPixelFormat.RS_FMT_RGBX8 => TextureFormat.RGBA32,
-                _ => throw new ArgumentOutOfRangeException()
-            };
-        }
 
         // isolated functions, do not require init prior to use
         unsafe delegate void pRegisterLogFunc(logger_t logger);

--- a/Runtime/PluginEntry.cs
+++ b/Runtime/PluginEntry.cs
@@ -36,7 +36,12 @@ namespace Disguise.RenderStream
 
         public static PluginEntry instance { get { return Nested.instance; } }
 
-        // Should match NativeRenderingPlugin::ToDXFormat in the native plugin's DX12Texture.h
+        /// <summary>
+        /// Returns the <see cref="GraphicsFormat"/> that matches a RenderStream <see cref="RSPixelFormat"/>.
+        /// </summary>
+        /// <param name="fmt">The RenderStream format.</param>
+        /// <param name="sRGB">When true, an sRGB variant will be picked if it exists.</param>
+        /// <remarks>Should match NativeRenderingPlugin::ToDXFormat in the native plugin's DX12Texture.h.</remarks>
         public static GraphicsFormat ToGraphicsFormat(RSPixelFormat fmt, bool sRGB)
         {
             // All textures are expected in the normalized 0-1 range.
@@ -44,20 +49,26 @@ namespace Disguise.RenderStream
             return fmt switch
             {
                 RSPixelFormat.RS_FMT_BGRA8 or RSPixelFormat.RS_FMT_BGRX8 => sRGB ? GraphicsFormat.B8G8R8A8_SRGB : GraphicsFormat.B8G8R8A8_UNorm,
-                RSPixelFormat.RS_FMT_RGBA32F => GraphicsFormat.R32G32B32_SFloat, // Has no UNorm format
+                RSPixelFormat.RS_FMT_RGBA32F => GraphicsFormat.R32G32B32A32_SFloat,
                 RSPixelFormat.RS_FMT_RGBA16 => GraphicsFormat.R16G16B16A16_UNorm,
                 RSPixelFormat.RS_FMT_RGBA8 or RSPixelFormat.RS_FMT_RGBX8 => sRGB ? GraphicsFormat.R8G8B8A8_SRGB : GraphicsFormat.R8G8B8A8_UNorm,    
                 _ => throw new ArgumentOutOfRangeException()
             };
         }
         
+        /// <summary>
+        /// Returns the <see cref="TextureFormat"/> that matches a RenderStream <see cref="RSPixelFormat"/>.
+        /// This should really only be used for <see cref="Texture2D.CreateExternalTexture"/>,
+        /// and not for actually creating textures because it doesn't carry any color space information.
+        /// </summary>
+        /// <remarks>Should match NativeRenderingPlugin::ToDXFormat in the native plugin's DX12Texture.h.</remarks>
         public static TextureFormat ToTextureFormat(RSPixelFormat fmt)
         {
             return fmt switch
             {
                 RSPixelFormat.RS_FMT_BGRA8 or RSPixelFormat.RS_FMT_BGRX8 => TextureFormat.BGRA32,
                 RSPixelFormat.RS_FMT_RGBA32F => TextureFormat.RGBAFloat,
-                RSPixelFormat.RS_FMT_RGBA16 => TextureFormat.RGBAHalf,
+                RSPixelFormat.RS_FMT_RGBA16 => TextureFormat.RGBA64,
                 RSPixelFormat.RS_FMT_RGBA8 or RSPixelFormat.RS_FMT_RGBX8 => TextureFormat.RGBA32,
                 _ => throw new ArgumentOutOfRangeException()
             };


### PR DESCRIPTION
Fixed `RSPixelFormat.RS_FMT_RGBA32F` => `GraphicsFormat.R32G32B32A32_SFloat`

Overall things are much simpler now, with only [1 conversion function in managed code](https://github.com/wenzhang-unity/RenderStream-Unity/pull/31/files#diff-d4bd53a892ab1e71d433aea6b9baffb28649f5e0fdb223641d528f2269ebaecaR45), and [1 conversion function in native code](https://github.com/wenzhang-unity/RenderStream-Unity/blob/dev/Native~/DX12Texture.h#L11).

Decided not to support fallback formats (using `SystemInfo.GetCompatibleFormat`) due to missing `GraphicsFormat` -> `DXGI_FORMAT` conversion function in Unity managed or native API.

A `DXGI_FORMAT` is used in the DX12 plugin to create a texture manually with the "shared" flag.

### Output textures
When an SRGB variant exists, the output texture will have an SRGB format.

The data sampled from our output textures will always be SRGB, regardless of the format.

### Input textures
Always linear, never use SRGB variants.