### PR TITLE
Indexing fix for debug presenter

### DIFF
--- a/Runtime/DisguiseCameraCapture.cs
+++ b/Runtime/DisguiseCameraCapture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -8,6 +9,8 @@ namespace Disguise.RenderStream
     [RequireComponent(typeof(Camera))]
     public class DisguiseCameraCapture : MonoBehaviour
     {
+        internal CameraCapture Capture => m_capture;
+        
         Camera m_camera;
         FrameSender m_frameSender;
         CameraCapture m_capture;
@@ -29,7 +32,7 @@ namespace Disguise.RenderStream
             m_cameraData = new CameraData();
 
             m_camera = GetComponent<Camera>();
-            var stream = Array.Find(m_RenderStream.Streams, s => s.name == gameObject.name);
+            var stream = m_RenderStream.Streams.FirstOrDefault(x => x.camera.gameObject.name == gameObject.name).description;
             m_frameSender = new FrameSender(gameObject.name, stream);
 
             m_capture = gameObject.AddComponent<CameraCapture>();

--- a/Runtime/DisguiseCameraCapture.cs
+++ b/Runtime/DisguiseCameraCapture.cs
@@ -32,7 +32,7 @@ namespace Disguise.RenderStream
             m_cameraData = new CameraData();
 
             m_camera = GetComponent<Camera>();
-            var stream = m_RenderStream.Streams.FirstOrDefault(x => x.description.name == gameObject.name).description;
+            var stream = m_RenderStream.Streams.FirstOrDefault(x => x.Description.name == gameObject.name).Description;
             m_frameSender = new FrameSender(gameObject.name, stream);
 
             m_capture = gameObject.AddComponent<CameraCapture>();

--- a/Runtime/DisguiseCameraCapture.cs
+++ b/Runtime/DisguiseCameraCapture.cs
@@ -32,7 +32,7 @@ namespace Disguise.RenderStream
             m_cameraData = new CameraData();
 
             m_camera = GetComponent<Camera>();
-            var stream = m_RenderStream.Streams.FirstOrDefault(x => x.camera.gameObject.name == gameObject.name).description;
+            var stream = m_RenderStream.Streams.FirstOrDefault(x => x.description.name == gameObject.name).description;
             m_frameSender = new FrameSender(gameObject.name, stream);
 
             m_capture = gameObject.AddComponent<CameraCapture>();

--- a/Runtime/DisguiseRenderStream.cs
+++ b/Runtime/DisguiseRenderStream.cs
@@ -13,6 +13,13 @@ namespace Disguise.RenderStream
 {
     class DisguiseRenderStream
     {
+        public struct DisguiseStream
+        {
+            public StreamDescription Description;
+            public Camera Camera;
+            public DisguiseCameraCapture Capture;
+        }
+        
         /// <summary>
         /// Initializes RenderStream objects.
         /// </summary>
@@ -213,7 +220,7 @@ namespace Disguise.RenderStream
             Debug.Log(string.Format("Found {0} streams", streams.Length));
             
             foreach (var stream in m_Streams)
-                UnityEngine.Object.Destroy(stream.camera.gameObject);
+                UnityEngine.Object.Destroy(stream.Camera.gameObject);
             
             Array.Resize(ref m_Streams, streams.Length);
 
@@ -226,7 +233,7 @@ namespace Disguise.RenderStream
             for (int i = 0; i < m_Streams.Length; ++i)
             {
                 StreamDescription stream = streams[i];
-                m_Streams[i].description = stream;
+                m_Streams[i].Description = stream;
                 
                 Camera channelCamera = GetChannelCamera(stream.channel);
                 GameObject cameraObject;
@@ -250,7 +257,7 @@ namespace Disguise.RenderStream
                 cameraObject.transform.localRotation = Quaternion.identity;
             
                 Camera camera = cameraObject.GetComponent<Camera>();
-                m_Streams[i].camera = camera;
+                m_Streams[i].Camera = camera;
                 
                 camera.enabled = true; // ensure the camera component is enable
                 camera.cullingMask &= cullUIOnly; // cull the UI so RenderStream and other error messages don't render to RenderStream outputs
@@ -259,10 +266,10 @@ namespace Disguise.RenderStream
             for (int i = 0; i < m_Streams.Length; ++i)
             {
                 var stream = m_Streams[i];
-                DisguiseCameraCapture capture = stream.camera.gameObject.GetComponent<DisguiseCameraCapture>();
+                DisguiseCameraCapture capture = stream.Camera.gameObject.GetComponent<DisguiseCameraCapture>();
                 if (capture == null)
-                    capture = stream.camera.gameObject.AddComponent<DisguiseCameraCapture>();
-                m_Streams[i].capture = capture;
+                    capture = stream.Camera.gameObject.AddComponent<DisguiseCameraCapture>();
+                m_Streams[i].Capture = capture;
             }
 
             // stop template cameras impacting performance
@@ -532,7 +539,7 @@ namespace Disguise.RenderStream
 
         public ManagedSchema Schema { get; } = new ();
 
-        public IReadOnlyList<(StreamDescription description, Camera camera, DisguiseCameraCapture capture)> Streams => m_Streams;
+        public IReadOnlyList<DisguiseStream> Streams => m_Streams;
         
         public IEnumerable<RenderTexture> InputTextures
         {
@@ -555,7 +562,7 @@ namespace Disguise.RenderStream
 
         public bool HasNewFrameData { get; protected set; }
 
-        (StreamDescription description, Camera camera, DisguiseCameraCapture capture)[] m_Streams = { };
+        DisguiseStream[] m_Streams = { };
 
         public struct SceneFields
         {

--- a/Runtime/PluginEntry.cs
+++ b/Runtime/PluginEntry.cs
@@ -241,7 +241,7 @@ namespace Disguise.RenderStream
                     for (int k = 0; k < parameter.nOptions; ++k)
                     {
                         IntPtr optionPtr = Marshal.ReadIntPtr(parameter.options, k * Marshal.SizeOf(typeof(IntPtr)));
-                        managedParameter.options[i] = Marshal.PtrToStringAnsi(optionPtr);
+                        managedParameter.options[k] = Marshal.PtrToStringAnsi(optionPtr);
                     }
                     managedParameter.dmxOffset = parameter.dmxOffset;
                     managedParameter.dmxType = parameter.dmxType;

--- a/Runtime/UnityDebugWindowPresenter.cs
+++ b/Runtime/UnityDebugWindowPresenter.cs
@@ -233,13 +233,21 @@ namespace Disguise.RenderStream
 
         void RefreshOutput()
         {
-            m_Outputs = FindObjectsByType<DisguiseCameraCapture>(
-                FindObjectsSortMode.InstanceID).Select(
-                    x => x.GetComponent<CameraCapture>()).ToArray();
+            var channels = DisguiseRenderStream.Instance.Schema.channels;
+            Array.Resize(ref m_Outputs, channels.Length);
+            Array.Fill(m_Outputs, null);
+            
+            // The list of streams is an unordered subset of the list of channels
+            foreach (var stream in DisguiseRenderStream.Instance.Streams)
+            {
+                var index = Array.IndexOf(channels, stream.description.channel);
+                m_Outputs[index] = stream.capture.Capture;
+            }
         }
         
         void RefreshInput()
         {
+            // InputTextures are in the same order as in the schema, no sorting required
             m_Inputs = DisguiseRenderStream.Instance.InputTextures.ToArray();
         }
     }

--- a/Runtime/UnityDebugWindowPresenter.cs
+++ b/Runtime/UnityDebugWindowPresenter.cs
@@ -240,8 +240,8 @@ namespace Disguise.RenderStream
             // The list of streams is an unordered subset of the list of channels
             foreach (var stream in DisguiseRenderStream.Instance.Streams)
             {
-                var index = Array.IndexOf(channels, stream.description.channel);
-                m_Outputs[index] = stream.capture.Capture;
+                var index = Array.IndexOf(channels, stream.Description.channel);
+                m_Outputs[index] = stream.Capture.Capture;
             }
         }
         


### PR DESCRIPTION
Combines the insight from PR #29 with a schema-based approach to make it compatible with #27.

Cleanup in DisguiseRenderStream.cs along the way:
* Exposed the schema
* Combined the `Streams` and `m_Cameras` lists (they were 1-to-1) + `CameraCapture` objects. All 3 objects were already being created together in `CreateStreams()` for each stream.